### PR TITLE
Enable manual mode for entering password

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ sudo ln -s ~/.lazy-connect/lazy-connect /usr/local/bin/lazy-connect
 lazy-connect - Shell function to fuzzy search an IPSec VPN by name
                and connect to it automatically.
 
--i    - Initialize lazy-connect.
+-n    - Connect to VPN by autofilling password
+-i    - Initialize lazy-connect. Stores the TOTP secret and VPN list
         Stores the secret and VPN list to ~/.config/lazy-connect/
+-u    - Update lazy-connect
 -r    - refresh vpn list in ~/.config/lazy-connect
 -h    - Show this help
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ lazy-connect - Shell function to fuzzy search an IPSec VPN by name
 -h    - Show this help
 ```
 
+## Configuration
+
+* The connection to VPN could be made with filling password automatically. To enable autofill set `LAZY_CONNECT_AUTOFILL` variable to true.
+
+```
+export LAZY_CONNECT_AUTOFILL="true"
+```
+When disabled, the password is copied to clipboard, and you can use it manually when it prompts for password.
+
 ### YubiKey Support
 
 #### Prerequisite

--- a/lazy-connect
+++ b/lazy-connect
@@ -113,7 +113,7 @@ function _lazy_connect() {
   if [ "$3" = "true" ]; then
     local _lazy_connect_auto_fill_pwd="true"
   else
-    echo "$password" | pbcopy
+    echo -n "$password" | pbcopy
   fi
 
   osascript <<EOF

--- a/lazy-connect
+++ b/lazy-connect
@@ -147,7 +147,7 @@ function lazy-connect() {
   local OPTIND
   mkdir -p $_lazy_connect_config_dir
 
-  while getopts "iruhn" opt; do
+  while getopts "irhn" opt; do
     case $opt in
       h)
         _lazy_connect_usage
@@ -163,7 +163,7 @@ function lazy-connect() {
         return 0
         ;;
       n)
-        local _secret=$(cat $_lazy_connect_config_dir/secret)
+        local _secret=$(security find-generic-password -a lazy-connect -w 2>/dev/null | tr -d '\n')
         local _vpn_name=$(cat $_lazy_connect_config_dir/vpns | fzf --height=10 --ansi --reverse --select-1)
         _lazy_connect "$_vpn_name" "$_secret" true
         return 0

--- a/lazy-connect.sh
+++ b/lazy-connect.sh
@@ -105,7 +105,7 @@ function _lazy_connect() {
     esac
   fi
 
-  [[ "$AUTOFILL" -eq "true" ]]  && echo -n "$password" | pbcopy
+  [[ "$LAZY_CONNECT_AUTOFILL" -eq "true" ]]  && echo -n "$password" | pbcopy
 
   osascript <<EOF
     on connectVpn(vpnName, password, autofill)
@@ -130,7 +130,7 @@ function _lazy_connect() {
       end tell
     end connectVpn
 
-    connectVpn("$vpn_name", "$password", "$AUTOFILL")
+    connectVpn("$vpn_name", "$password", "$LAZY_CONNECT_AUTOFILL")
 EOF
 }
 

--- a/lazy-connect.sh
+++ b/lazy-connect.sh
@@ -105,8 +105,10 @@ function _lazy_connect() {
     esac
   fi
 
+  [[ "$MANUAL_MODE" -eq "true" ]]  && echo -n "$password" | pbcopy
+
   osascript <<EOF
-    on connectVpn(vpnName, password)
+    on connectVpn(vpnName, password, manual)
       tell application "System Events"
         tell process "SystemUIServer"
           set vpnMenu to (menu bar item 1 of menu bar 1 where description is "VPN")
@@ -114,8 +116,11 @@ function _lazy_connect() {
           try
             click menu item vpnName of menu 1 of vpnMenu
             delay 1
-            keystroke password
-            keystroke return
+            if (manual is not equal to "true")
+              keystroke $password
+              keystroke return
+            end if
+            return "true"
           on error errorStr
             if errorStr does not contain "Can’t get menu item" and errorStr does not contain vpnName then
               display dialog errorStr
@@ -125,7 +130,7 @@ function _lazy_connect() {
       end tell
     end connectVpn
 
-    connectVpn("$vpn_name", "$password")
+    connectVpn("$vpn_name", "$password", "$MANUAL_MODE")
 EOF
 }
 

--- a/lazy-connect.sh
+++ b/lazy-connect.sh
@@ -105,10 +105,10 @@ function _lazy_connect() {
     esac
   fi
 
-  [[ "$MANUAL_MODE" -eq "true" ]]  && echo -n "$password" | pbcopy
+  [[ "$AUTOFILL" -eq "true" ]]  && echo -n "$password" | pbcopy
 
   osascript <<EOF
-    on connectVpn(vpnName, password, manual)
+    on connectVpn(vpnName, password, autofill)
       tell application "System Events"
         tell process "SystemUIServer"
           set vpnMenu to (menu bar item 1 of menu bar 1 where description is "VPN")
@@ -116,11 +116,11 @@ function _lazy_connect() {
           try
             click menu item vpnName of menu 1 of vpnMenu
             delay 1
-            if (manual is not equal to "true")
+            if (autofill is equal to "true")
               keystroke $password
               keystroke return
             end if
-            return "true"
+            return
           on error errorStr
             if errorStr does not contain "Can’t get menu item" and errorStr does not contain vpnName then
               display dialog errorStr
@@ -130,7 +130,7 @@ function _lazy_connect() {
       end tell
     end connectVpn
 
-    connectVpn("$vpn_name", "$password", "$MANUAL_MODE")
+    connectVpn("$vpn_name", "$password", "$AUTOFILL")
 EOF
 }
 


### PR DESCRIPTION
- When there's delay in connecting to vpn, the password is entered in terminal

There's no sync between window opening and password input, This change makes the `enter` step manual with password in clipboard.